### PR TITLE
fix: return chain promises effect

### DIFF
--- a/packages/loading/src/index.ts
+++ b/packages/loading/src/index.ts
@@ -233,7 +233,7 @@ export default <
 						// check if result is a promise
 						if (effectResult?.then) {
 							// hide loading when promise finishes either with success or error
-							effectResult
+							return effectResult
 								.then((r: any) => {
 									rematch.dispatch[loadingModelName].hide({ name, action })
 									return r
@@ -242,10 +242,10 @@ export default <
 									rematch.dispatch[loadingModelName].hide({ name, action })
 									throw err
 								})
-						} else {
-							// original action doesn't return a promise so there's nothing to wait for
-							rematch.dispatch[loadingModelName].hide({ name, action })
 						}
+
+						// original action doesn't return a promise so there's nothing to wait for
+						rematch.dispatch[loadingModelName].hide({ name, action })
 
 						// return the original result of this reducer
 						return effectResult


### PR DESCRIPTION
Return the chain promise to propagate the throw error and continue the chaining normally.
Fix the Unhandled Promise Rejection